### PR TITLE
Use relative URL in logout link

### DIFF
--- a/Resources/Private/Templates/FrontendLogin/ShowLogout.html
+++ b/Resources/Private/Templates/FrontendLogin/ShowLogout.html
@@ -1,3 +1,3 @@
-<a href="/?logintype=logout">
+<a href="./?logintype=logout">
     <f:translate key="logout"/>
 </a>


### PR DESCRIPTION
Generated logout link assumes the homepage will be able to proceed to logout. 

This might not always be the case, e.g if the shibboleth-protected section of a specific website is only to be found under a specific subpath (https://my-site.com/protected/my-protected-page). In those cases, using the Shibboleth Login Plugin can prevent the user to log out of the Frontend.

A quick workaround to that situation is to use a relative URL pointing to the current page being viewed + the logout get parameter