### PR TITLE
[TASK] Improve set cookie by using native php function

### DIFF
--- a/Classes/Typo3/Service/ShibbolethAuthenticationService.php
+++ b/Classes/Typo3/Service/ShibbolethAuthenticationService.php
@@ -263,9 +263,6 @@ class ShibbolethAuthenticationService extends AbstractAuthenticationService
         return implode(',', $frontendUserGroupUids);
     }
 
-    /**
-     * @return boolean
-     */
     protected function isShibbolethLogin(): bool
     {
         if (
@@ -273,18 +270,18 @@ class ShibbolethAuthenticationService extends AbstractAuthenticationService
             || $_COOKIE['be_disableShibboleth']
         ) {
             $cookieSecure = (bool)$GLOBALS['TYPO3_CONF_VARS']['SYS']['cookieSecure'] && GeneralUtility::getIndpEnv('TYPO3_SSL');
-            $cookie = new Cookie(
+            setcookie(
                 'be_disableShibboleth',
                 '1',
-                GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('date', 'timestamp') + 3600, // 1 hour
-                GeneralUtility::getIndpEnv('TYPO3_SITE_PATH') . TYPO3_mainDir,
-                '',
-                $cookieSecure,
-                true,
-                false,
-                Cookie::SAMESITE_STRICT
+                [
+                    'expires' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('date', 'timestamp') + 3600, // 1 hour
+                    'path' => GeneralUtility::getIndpEnv('TYPO3_SITE_PATH') . TYPO3_mainDir,
+                    'domain' => '',
+                    'secure' => $cookieSecure,
+                    'httponly' => true,
+                    'samesite' => Cookie::SAMESITE_STRICT,
+                ]
             );
-            header('Set-Cookie: ' . $cookie->__toString(), false);
 
             return false;
         }


### PR DESCRIPTION
Empirical experiments have shown that using the PHP native function correctly sets the cookie, as opposed to sending the "cookie" header.