### PR TITLE
Fix undefined array key REMOTE_USER warning in init()

### DIFF
--- a/Classes/Typo3/Service/ShibbolethAuthenticationService.php
+++ b/Classes/Typo3/Service/ShibbolethAuthenticationService.php
@@ -50,7 +50,7 @@ class ShibbolethAuthenticationService extends AbstractAuthenticationService
         if (empty($this->extensionConfiguration['displayName'])) {
             $this->extensionConfiguration['displayName'] = 'displayName';
         }
-        $this->remoteUser = $_SERVER[$this->extensionConfiguration['remoteUser']];
+        $this->remoteUser = $_SERVER[$this->extensionConfiguration['remoteUser']] ?? null;
         return parent::init();
     }
 


### PR DESCRIPTION
## Summary

- Fix PHP Warning `Undefined array key "REMOTE_USER"` in `ShibbolethAuthenticationService::init()` when no Shibboleth session is active

## Problem

Every non-Shibboleth request to the TYPO3 backend triggers:
```
PHP Warning: Undefined array key "REMOTE_USER" in
Classes/Typo3/Service/ShibbolethAuthenticationService.php line 53
```

## Solution

Use the null coalescing operator to default `$this->remoteUser` to `null` when `$_SERVER['REMOTE_USER']` is not set. This is safe because:
- The property is already typed as `?string`
- All usages check for `null`/empty via `empty($this->remoteUser)`

Fixes #12