### PR TITLE
[TASK] Port deprecated hook logoff_post_processing to EventListener

### DIFF
--- a/Classes/EventListener/LogoutListener.php
+++ b/Classes/EventListener/LogoutListener.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace Visol\ShibbolethAuth\Hook;
+namespace Visol\ShibbolethAuth\EventListener;
 
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Authentication\Event\AfterUserLoggedOutEvent;
 use TYPO3\CMS\Core\Utility\StringUtility;
 
 /**
@@ -17,10 +19,13 @@ use TYPO3\CMS\Core\Utility\StringUtility;
  * The TYPO3 project - inspiring people to share!
  */
 
-class UserAuthentication
+#[AsEventListener(
+    identifier: 'shibboleth-auth/logout-listener',
+)]
+final readonly class LogoutListener
 {
 
-    public function backendLogoutHandler()
+    public function __invoke(AfterUserLoggedOutEvent $event): void
     {
         // Delete the Shibboleth session cookie
         foreach ($_COOKIE as $name => $value) {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,6 @@
 use Visol\ShibbolethAuth\Controller\FrontendLoginController;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use Visol\ShibbolethAuth\Hook\UserAuthentication;
 use Visol\ShibbolethAuth\LoginProvider\ShibbolethLoginProvider;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -22,10 +21,6 @@ defined('TYPO3') || die();
         $subTypes[] = 'authUserBE';
 
         $GLOBALS['TYPO3_CONF_VARS']['SVCONF']['auth']['setup']['BE_fetchUserIfNoSession'] = $extensionConfiguration['BE_fetchUserIfNoSession'];
-
-        // Register backend logout handler
-        // TODO: Replace with https://docs.typo3.org/permalink/t3coreapi:afteruserloggedoutevent
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_userauth.php']['logoff_post_processing'][] = UserAuthentication::class . '->backendLogoutHandler';
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['backend']['loginProviders'][1518433441] = [
             'provider' => ShibbolethLoginProvider::class,


### PR DESCRIPTION
# Issue

Backend-Users who logged in through Shibboleth cannot log-out anymore, they will always be redirected to the backend interface with a (new) valid session. 

According to [Breaking: #100963 - Deprecated functionality removed](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-100963-DeprecatedFunctionalityRemoved.html#breaking-100963-deprecated-functionality-removed), `$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_userauth.php']['logoff_post_processing']` was removed in TYPO3 v13.0 and should be migrated to the PSR-14 event `\TYPO3\CMS\Core\Authentication\Event\AfterUserLoggedOutEvent` introduced in TYPO3 v12.3

# Changes

The `UserAuthentication` Hook was turned into an eventListener.